### PR TITLE
lib/goom2k4-0/configure.in: fix powerpc support on non-apple machines

### DIFF
--- a/lib/goom2k4-0/configure.in
+++ b/lib/goom2k4-0/configure.in
@@ -59,7 +59,7 @@ i*86_64-*-*)
 	HAVE_MMX="yes"
 	;;
 
-powerpc-*-*)
+powerpc-apple-darwin*)
   	CCASFLAGS=-force_cpusubtype_ALL
   	AC_SUBST(CCASFLAGS)
 	AC_DEFINE(CPU_POWERPC)


### PR DESCRIPTION
Fixes buildroot build error with gcc target
powerpc-buildroot-linux-uclibc:

unrecognised option: '-force_cpusubtype_ALL'