### PR TITLE
lib/goom2k4-0: fix static build

### DIFF
--- a/lib/goom2k4-0/CMakeLists.txt
+++ b/lib/goom2k4-0/CMakeLists.txt
@@ -51,3 +51,4 @@ set(GOOM_HEADERS src/goom.h
                  src/xmmx.h)
 
 add_library(goom STATIC ${GOOM_SOURCES} ${GOOM_HEADERS})
+set_property(TARGET goom PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Fixes build error:

[100%] Linking CXX shared library visualization.goom.so
/home/buildroot/br8/output/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/7.4.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld:
 lib/goom2k4-0/libgoom.a(goom_core.c.o):
 relocation R_X86_64_32S against `.rodata' can not be used when making
 a shared object; recompile with -fPIC